### PR TITLE
Fix build.sbt formatting issues

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -13,10 +13,7 @@ lazy val root = (project in file(".")).settings(
     "org.typelevel" %% "cats-effect-std" % "3.0.1"$if(scala3.truthy)$$else$,
     // better monadic for compiler plugin as suggested by documentation
     compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")$endif$$if(testlib-use-cats-effect-testing-specs2.truthy)$,
-
-    "org.typelevel" %% "cats-effect-testing-specs2" % "1.0.1" % Test$else$
-
-    $endif$$if(testlib-use-munit-cats-effect-3.truthy)$,
+    "org.typelevel" %% "cats-effect-testing-specs2" % "1.0.1" % Test$else$$endif$$if(testlib-use-munit-cats-effect-3.truthy)$,
     "org.typelevel" %% "munit-cats-effect-3" % "1.0.1" % Test$else$$endif$
 
   )


### PR DESCRIPTION
I've created a minor formatting issue for build.sbt in my previous PR. This PR fixes that formatting issue

**Before**
<img width="672" alt="image" src="https://user-images.githubusercontent.com/1117733/113791756-3b150f80-973c-11eb-923b-c8e14793d21e.png">

**After**
<img width="672" alt="image" src="https://user-images.githubusercontent.com/1117733/113791863-7dd6e780-973c-11eb-97e7-ce7cdfc83986.png">

