### PR TITLE
scala3 flag now handles scalaVersion too

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.example"
-ThisBuild / scalaVersion := "2.13.5"
+ThisBuild / scalaVersion := $if(scala3.truthy)$"3.0.0-RC2"$else$"2.13.5"$endif$
 
 lazy val root = (project in file(".")).settings(
   name := "$name;format="norm"$",

--- a/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/src/main/scala/$package$/Main.scala
@@ -7,5 +7,5 @@ object Main extends IOApp.Simple {
 
   // This is your new "main"!
   def run: IO[Unit] =
-    HelloWorld.say$if(scala3.truthy)$()$endif$.flatMap(IO.println)
+    HelloWorld.say().flatMap(IO.println)
 }

--- a/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/src/main/scala/$package$/Main.scala
@@ -7,5 +7,5 @@ object Main extends IOApp.Simple {
 
   // This is your new "main"!
   def run: IO[Unit] =
-    HelloWorld.say.flatMap(IO.println)
+    HelloWorld.say$if(scala3.truthy)$()$endif$.flatMap(IO.println)
 }

--- a/src/main/g8/src/test/scala/$package$/$if(testlib-use-cats-effect-testing-specs2.truthy)$.$endif$/HelloWorldSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/$if(testlib-use-cats-effect-testing-specs2.truthy)$.$endif$/HelloWorldSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 class ExampleSpec extends Specification with CatsEffect {
   "examples" should {
     "say hello" in {
-      HelloWorld.say$if(scala3.truthy)$()$endif$.map(_ === "Hello Cats!")
+      HelloWorld.say().map(_ === "Hello Cats!")
     }
   }
 }

--- a/src/main/g8/src/test/scala/$package$/$if(testlib-use-cats-effect-testing-specs2.truthy)$.$endif$/HelloWorldSpec.scala
+++ b/src/main/g8/src/test/scala/$package$/$if(testlib-use-cats-effect-testing-specs2.truthy)$.$endif$/HelloWorldSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 class ExampleSpec extends Specification with CatsEffect {
   "examples" should {
     "say hello" in {
-      HelloWorld.say.map(_ === "Hello Cats!")
+      HelloWorld.say$if(scala3.truthy)$()$endif$.map(_ === "Hello Cats!")
     }
   }
 }

--- a/src/main/g8/src/test/scala/$package$/$if(testlib-use-munit-cats-effect-3.truthy)$.$endif$/HelloWorldSuite.scala
+++ b/src/main/g8/src/test/scala/$package$/$if(testlib-use-munit-cats-effect-3.truthy)$.$endif$/HelloWorldSuite.scala
@@ -6,6 +6,6 @@ import munit.CatsEffectSuite
 class HelloWorldSuite extends CatsEffectSuite {
 
   test("test hello world says hi") {
-    HelloWorld.say.map(it => assertEquals(it, "Hello Cats!"))
+    HelloWorld.say$if(scala3.truthy)$()$endif$.map(it => assertEquals(it, "Hello Cats!"))
   }
 }

--- a/src/main/g8/src/test/scala/$package$/$if(testlib-use-munit-cats-effect-3.truthy)$.$endif$/HelloWorldSuite.scala
+++ b/src/main/g8/src/test/scala/$package$/$if(testlib-use-munit-cats-effect-3.truthy)$.$endif$/HelloWorldSuite.scala
@@ -6,6 +6,6 @@ import munit.CatsEffectSuite
 class HelloWorldSuite extends CatsEffectSuite {
 
   test("test hello world says hi") {
-    HelloWorld.say$if(scala3.truthy)$()$endif$.map(it => assertEquals(it, "Hello Cats!"))
+    HelloWorld.say().map(it => assertEquals(it, "Hello Cats!"))
   }
 }


### PR DESCRIPTION
As proposed by @kubukoz [here](https://github.com/typelevel/ce3.g8/pull/17#issuecomment-820847758) scala3 flag now handles scalaVersion too.

IMHO once scala3 arrives we can consider adding a `langVersion` or `scalaVersion` variable handled by g8 like `maven(org.scala, scala-lang, stable)` or better let @scala-steward handle it.