### PR TITLE
Enable -source:future for Scala 3.

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,7 @@
 ThisBuild / organization := "com.example"
 ThisBuild / scalaVersion := $if(scala3.truthy)$"3.0.0"$else$"2.13.5"$endif$
+$if(scala3.truthy)$ThisBuild / scalacOptions += "-source:future"
+$endif$
 
 lazy val root = (project in file(".")).settings(
   name := "$name;format="norm"$",


### PR DESCRIPTION
The `better-monadic-for` plugin is not needed for Scala 3, but it seems that you do need the equivalent `-source:future` flag in order to get the improved for-comprehensions. Otherwise you get the classic errors about thing like the `withFilter` method being undefined, and briefly confused users such as me.